### PR TITLE
Gitea integration: commit status + PR coverage comments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish OpenCov Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        run: |
+          OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${OWNER}/opencov"
+          TAGS=""
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${{ github.ref_name }}"
+            TAGS="${IMAGE}:${VERSION},${IMAGE}:latest"
+          else
+            TAGS="${IMAGE}:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/config/config.exs
+++ b/config/config.exs
@@ -47,6 +47,13 @@ config :opencov, :demo,
   email: "user@opencov.com",
   password: "password123"
 
+config :opencov, :gitea,
+  enabled: System.get_env("GITEA_ENABLED") == "true",
+  url: System.get_env("GITEA_URL"),
+  token: System.get_env("GITEA_TOKEN"),
+  post_commit_status: true,
+  post_pr_comment: true
+
 import_config "#{Mix.env}.exs"
 
 local_config_path = Path.expand("local.exs", __DIR__)

--- a/lib/opencov/integrations/gitea.ex
+++ b/lib/opencov/integrations/gitea.ex
@@ -1,0 +1,282 @@
+defmodule Opencov.Integrations.Gitea do
+  @moduledoc """
+  Gitea integration: posts commit status and PR comments after coverage processing.
+  """
+
+  require Logger
+
+  def notify(build) do
+    config = Application.get_env(:opencov, :gitea, [])
+    if config[:enabled] && config[:url] && config[:token] do
+      Task.start(fn -> do_notify(build, config) end)
+    end
+  end
+
+  defp do_notify(build, config) do
+    build = Opencov.Repo.preload(build, [:project, jobs: :files])
+
+    case parse_repo(build.project.base_url, config[:url]) do
+      {:ok, owner, repo} ->
+        if config[:post_commit_status] && build.commit_sha do
+          post_commit_status(config, owner, repo, build)
+        end
+
+        if config[:post_pr_comment] && build.service_job_pull_request do
+          post_pr_comment(config, owner, repo, build)
+        end
+
+      :error ->
+        Logger.warning("Gitea: cannot parse repo from base_url=#{build.project.base_url}")
+    end
+  end
+
+  defp parse_repo(base_url, gitea_url) do
+    gitea_host = URI.parse(gitea_url).host
+    uri = URI.parse(base_url)
+
+    if uri.host == gitea_host do
+      parts = uri.path |> String.trim_leading("/") |> String.trim_trailing(".git") |> String.split("/")
+      case parts do
+        [owner, repo | _] -> {:ok, owner, repo}
+        _ -> :error
+      end
+    else
+      :error
+    end
+  end
+
+  # --- Commit Status ---
+
+  defp post_commit_status(config, owner, repo, build) do
+    delta = format_delta(build)
+    state = "success"
+    description = "Coverage: #{format_pct(build.coverage)}#{delta}"
+    target_url = build_url(build)
+
+    url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/statuses/#{build.commit_sha}"
+    body = Jason.encode!(%{
+      state: state,
+      target_url: target_url,
+      description: description,
+      context: "coverage/opencov"
+    })
+
+    case api_request(:post, url, body, config[:token]) do
+      {:ok, _} -> Logger.info("Gitea: posted commit status for #{build.commit_sha}")
+      {:error, reason} -> Logger.error("Gitea: failed to post commit status: #{inspect(reason)}")
+    end
+  end
+
+  # --- PR Comment ---
+
+  defp post_pr_comment(config, owner, repo, build) do
+    pr_number = build.service_job_pull_request
+    comment_body = format_pr_comment(build)
+    marker = "<!-- opencov-report -->"
+    full_body = "#{marker}\n#{comment_body}"
+
+    url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/#{pr_number}/comments"
+
+    # Check for existing comment to update
+    case find_existing_comment(config, owner, repo, pr_number, marker) do
+      {:ok, comment_id} ->
+        edit_url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/comments/#{comment_id}"
+        body = Jason.encode!(%{body: full_body})
+        case api_request(:patch, edit_url, body, config[:token]) do
+          {:ok, _} -> Logger.info("Gitea: updated PR comment for PR ##{pr_number}")
+          {:error, reason} -> Logger.error("Gitea: failed to update PR comment: #{inspect(reason)}")
+        end
+
+      :not_found ->
+        body = Jason.encode!(%{body: full_body})
+        case api_request(:post, url, body, config[:token]) do
+          {:ok, _} -> Logger.info("Gitea: posted PR comment for PR ##{pr_number}")
+          {:error, reason} -> Logger.error("Gitea: failed to post PR comment: #{inspect(reason)}")
+        end
+    end
+  end
+
+  defp find_existing_comment(config, owner, repo, pr_number, marker) do
+    url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/#{pr_number}/comments"
+    case api_request(:get, url, nil, config[:token]) do
+      {:ok, %{body: body}} ->
+        comments = Jason.decode!(body)
+        case Enum.find(comments, fn c -> String.contains?(c["body"] || "", marker) end) do
+          nil -> :not_found
+          comment -> {:ok, comment["id"]}
+        end
+      {:error, _} -> :not_found
+    end
+  end
+
+  # --- Comment Formatting ---
+
+  defp format_pr_comment(build) do
+    all_files = build.jobs |> Enum.flat_map(& &1.files)
+    target_url = build_url(build)
+
+    # Files that lost coverage
+    files_with_reduction = all_files
+      |> Enum.filter(fn f -> f.previous_coverage && f.coverage < f.previous_coverage end)
+      |> Enum.sort_by(fn f -> f.previous_coverage - f.coverage end)
+
+    # Changed files (new or source changed)
+    changed_files = all_files
+      |> Enum.filter(fn f -> is_nil(f.previous_coverage) end)
+
+    # Stats
+    total_relevant = all_files |> Enum.map(fn f -> Opencov.File.relevant_lines_count(f.coverage_lines || []) end) |> Enum.sum()
+    total_covered = all_files |> Enum.map(fn f -> Opencov.File.covered_lines_count(f.coverage_lines || []) end) |> Enum.sum()
+
+    changed_relevant = changed_files |> Enum.map(fn f -> Opencov.File.relevant_lines_count(f.coverage_lines || []) end) |> Enum.sum()
+    changed_covered = changed_files |> Enum.map(fn f -> Opencov.File.covered_lines_count(f.coverage_lines || []) end) |> Enum.sum()
+
+    new_missed = files_with_reduction |> Enum.map(fn f ->
+      prev_covered = if f.previous_coverage && f.previous_coverage > 0 do
+        relevant = Opencov.File.relevant_lines_count(f.coverage_lines || [])
+        round(f.previous_coverage * relevant / 100)
+      else
+        0
+      end
+      current_covered = Opencov.File.covered_lines_count(f.coverage_lines || [])
+      max(0, prev_covered - current_covered)
+    end) |> Enum.sum()
+
+    delta = format_delta(build)
+    badge_color = cond do
+      build.coverage >= 90 -> "brightgreen"
+      build.coverage >= 75 -> "green"
+      build.coverage >= 60 -> "yellow"
+      build.coverage >= 40 -> "orange"
+      true -> "red"
+    end
+    badge_pct = build.coverage |> Float.round(0) |> trunc()
+
+    """
+    ## Pull Request Test Coverage Report for [Build #{build.build_number}](#{target_url})
+
+    ---
+
+    ### Details
+
+    - **#{changed_covered}** of **#{changed_relevant}** changed or added relevant lines in **#{length(changed_files)}** files are covered.
+    - **#{new_missed}** unchanged lines in **#{length(files_with_reduction)}** files lost coverage.
+    - Overall coverage #{delta_direction(build)} (#{delta}) to **#{format_pct(build.coverage)}**
+
+    ---
+
+    #{format_files_table(files_with_reduction, target_url)}
+
+    | **Totals** | ![coverage](https://img.shields.io/badge/coverage-#{badge_pct}%25-#{badge_color}) |
+    |---|---|
+    | Change from base [Build #{previous_build_number(build)}](#{previous_build_url(build)}): | #{delta} |
+    | Covered Lines: | #{total_covered} |
+    | Relevant Lines: | #{total_relevant} |
+
+    ---
+    """
+  end
+
+  defp format_files_table([], _target_url), do: ""
+  defp format_files_table(files, target_url) do
+    header = """
+    | Files with Coverage Reduction | New Missed Lines | % |
+    |---|---|---|
+    """
+
+    rows = files
+      |> Enum.map(fn f ->
+        relevant = Opencov.File.relevant_lines_count(f.coverage_lines || [])
+        prev_covered = if f.previous_coverage && f.previous_coverage > 0,
+          do: round(f.previous_coverage * relevant / 100),
+          else: 0
+        current_covered = Opencov.File.covered_lines_count(f.coverage_lines || [])
+        missed = max(0, prev_covered - current_covered)
+        "| [#{f.name}](#{target_url}/source?filename=#{URI.encode(f.name)}) | #{missed} | #{format_pct(f.coverage)} |"
+      end)
+      |> Enum.join("\n")
+
+    header <> rows <> "\n"
+  end
+
+  # --- Helpers ---
+
+  defp format_pct(nil), do: "0%"
+  defp format_pct(coverage) do
+    "#{Float.round(coverage * 1.0, 2)}%"
+  end
+
+  defp format_delta(build) do
+    if build.previous_coverage do
+      delta = Float.round(build.coverage - build.previous_coverage, 1)
+      sign = if delta >= 0, do: "+", else: ""
+      "#{sign}#{delta}%"
+    else
+      ""
+    end
+  end
+
+  defp delta_direction(build) do
+    if build.previous_coverage do
+      if build.coverage >= build.previous_coverage, do: "increased", else: "decreased"
+    else
+      "is"
+    end
+  end
+
+  defp previous_build_number(build) do
+    if build.previous_build_id do
+      case Opencov.Repo.get(Opencov.Build, build.previous_build_id) do
+        nil -> "N/A"
+        prev -> "#{prev.build_number}"
+      end
+    else
+      "N/A"
+    end
+  end
+
+  defp build_url(build) do
+    base = Application.get_env(:opencov, :base_url) || ""
+    "#{base}/builds/#{build.id}"
+  end
+
+  defp previous_build_url(build) do
+    if build.previous_build_id do
+      base = Application.get_env(:opencov, :base_url) || ""
+      "#{base}/builds/#{build.previous_build_id}"
+    else
+      "#"
+    end
+  end
+
+  defp api_request(:get, url, _body, token) do
+    headers = [
+      {"Authorization", "token #{token}"},
+      {"Accept", "application/json"}
+    ]
+    case HTTPoison.get(url, headers, recv_timeout: 10_000) do
+      {:ok, %HTTPoison.Response{status_code: code} = resp} when code in 200..299 ->
+        {:ok, resp}
+      {:ok, %HTTPoison.Response{status_code: code, body: body}} ->
+        {:error, "HTTP #{code}: #{body}"}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, reason}
+    end
+  end
+
+  defp api_request(method, url, body, token) do
+    headers = [
+      {"Authorization", "token #{token}"},
+      {"Content-Type", "application/json"},
+      {"Accept", "application/json"}
+    ]
+    case HTTPoison.request(method, url, body, headers, recv_timeout: 10_000) do
+      {:ok, %HTTPoison.Response{status_code: code} = resp} when code in 200..299 ->
+        {:ok, resp}
+      {:ok, %HTTPoison.Response{status_code: code, body: resp_body}} ->
+        {:error, "HTTP #{code}: #{resp_body}"}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/opencov/integrations/gitea.ex
+++ b/lib/opencov/integrations/gitea.ex
@@ -6,14 +6,33 @@ defmodule Opencov.Integrations.Gitea do
   require Logger
 
   def notify(build) do
-    config = Application.get_env(:opencov, :gitea, [])
+    config = get_config()
     if config[:enabled] && config[:url] && config[:token] do
-      Task.start(fn -> do_notify(build, config) end)
+      Task.start(fn ->
+        try do
+          do_notify(build, config)
+        rescue
+          e -> Logger.error("Gitea notify failed: #{Exception.message(e)}")
+        end
+      end)
     end
   end
 
+  defp get_config do
+    # Read from Application env (set at boot from config files),
+    # with runtime overrides from environment variables
+    app_config = Application.get_env(:opencov, :gitea, [])
+    %{
+      enabled: (System.get_env("GITEA_ENABLED") || to_string(app_config[:enabled])) == "true",
+      url: System.get_env("GITEA_URL") || app_config[:url],
+      token: System.get_env("GITEA_TOKEN") || app_config[:token],
+      post_commit_status: Keyword.get(app_config, :post_commit_status, true),
+      post_pr_comment: Keyword.get(app_config, :post_pr_comment, true)
+    }
+  end
+
   defp do_notify(build, config) do
-    build = Opencov.Repo.preload(build, [:project, jobs: :files])
+    build = Opencov.Repo.preload(build, [:project, :previous_build, jobs: :files])
 
     case parse_repo(build.project.base_url, config[:url]) do
       {:ok, owner, repo} ->
@@ -21,7 +40,8 @@ defmodule Opencov.Integrations.Gitea do
           post_commit_status(config, owner, repo, build)
         end
 
-        if config[:post_pr_comment] && build.service_job_pull_request do
+        pr = build.service_job_pull_request
+        if config[:post_pr_comment] && is_binary(pr) && String.trim(pr) != "" do
           post_pr_comment(config, owner, repo, build)
         end
 
@@ -30,32 +50,32 @@ defmodule Opencov.Integrations.Gitea do
     end
   end
 
-  defp parse_repo(base_url, gitea_url) do
+  defp parse_repo(base_url, gitea_url) when is_binary(base_url) and is_binary(gitea_url) do
     gitea_host = URI.parse(gitea_url).host
     uri = URI.parse(base_url)
 
     if uri.host == gitea_host do
       parts = uri.path |> String.trim_leading("/") |> String.trim_trailing(".git") |> String.split("/")
       case parts do
-        [owner, repo | _] -> {:ok, owner, repo}
+        [owner, repo | _] when byte_size(owner) > 0 and byte_size(repo) > 0 -> {:ok, owner, repo}
         _ -> :error
       end
     else
       :error
     end
   end
+  defp parse_repo(_, _), do: :error
 
   # --- Commit Status ---
 
   defp post_commit_status(config, owner, repo, build) do
     delta = format_delta(build)
-    state = "success"
     description = "Coverage: #{format_pct(build.coverage)}#{delta}"
     target_url = build_url(build)
 
     url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/statuses/#{build.commit_sha}"
     body = Jason.encode!(%{
-      state: state,
+      state: "success",
       target_url: target_url,
       description: description,
       context: "coverage/opencov"
@@ -70,14 +90,11 @@ defmodule Opencov.Integrations.Gitea do
   # --- PR Comment ---
 
   defp post_pr_comment(config, owner, repo, build) do
-    pr_number = build.service_job_pull_request
+    pr_number = String.trim(build.service_job_pull_request)
     comment_body = format_pr_comment(build)
     marker = "<!-- opencov-report -->"
     full_body = "#{marker}\n#{comment_body}"
 
-    url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/#{pr_number}/comments"
-
-    # Check for existing comment to update
     case find_existing_comment(config, owner, repo, pr_number, marker) do
       {:ok, comment_id} ->
         edit_url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/comments/#{comment_id}"
@@ -88,6 +105,7 @@ defmodule Opencov.Integrations.Gitea do
         end
 
       :not_found ->
+        url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/#{pr_number}/comments"
         body = Jason.encode!(%{body: full_body})
         case api_request(:post, url, body, config[:token]) do
           {:ok, _} -> Logger.info("Gitea: posted PR comment for PR ##{pr_number}")
@@ -100,10 +118,13 @@ defmodule Opencov.Integrations.Gitea do
     url = "#{config[:url]}/api/v1/repos/#{owner}/#{repo}/issues/#{pr_number}/comments"
     case api_request(:get, url, nil, config[:token]) do
       {:ok, %{body: body}} ->
-        comments = Jason.decode!(body)
-        case Enum.find(comments, fn c -> String.contains?(c["body"] || "", marker) end) do
-          nil -> :not_found
-          comment -> {:ok, comment["id"]}
+        case Jason.decode(body) do
+          {:ok, comments} when is_list(comments) ->
+            case Enum.find(comments, fn c -> String.contains?(c["body"] || "", marker) end) do
+              nil -> :not_found
+              comment -> {:ok, comment["id"]}
+            end
+          _ -> :not_found
         end
       {:error, _} -> :not_found
     end
@@ -113,18 +134,24 @@ defmodule Opencov.Integrations.Gitea do
 
   defp format_pr_comment(build) do
     all_files = build.jobs |> Enum.flat_map(& &1.files)
+
+    if Enum.empty?(all_files) do
+      "## Coverage Report for [Build #{build.build_number}](#{build_url(build)})\n\nNo coverage data available."
+    else
+      do_format_pr_comment(build, all_files)
+    end
+  end
+
+  defp do_format_pr_comment(build, all_files) do
     target_url = build_url(build)
 
-    # Files that lost coverage
     files_with_reduction = all_files
       |> Enum.filter(fn f -> f.previous_coverage && f.coverage < f.previous_coverage end)
       |> Enum.sort_by(fn f -> f.previous_coverage - f.coverage end)
 
-    # Changed files (new or source changed)
     changed_files = all_files
       |> Enum.filter(fn f -> is_nil(f.previous_coverage) end)
 
-    # Stats
     total_relevant = all_files |> Enum.map(fn f -> Opencov.File.relevant_lines_count(f.coverage_lines || []) end) |> Enum.sum()
     total_covered = all_files |> Enum.map(fn f -> Opencov.File.covered_lines_count(f.coverage_lines || []) end) |> Enum.sum()
 
@@ -132,12 +159,10 @@ defmodule Opencov.Integrations.Gitea do
     changed_covered = changed_files |> Enum.map(fn f -> Opencov.File.covered_lines_count(f.coverage_lines || []) end) |> Enum.sum()
 
     new_missed = files_with_reduction |> Enum.map(fn f ->
-      prev_covered = if f.previous_coverage && f.previous_coverage > 0 do
-        relevant = Opencov.File.relevant_lines_count(f.coverage_lines || [])
-        round(f.previous_coverage * relevant / 100)
-      else
-        0
-      end
+      relevant = Opencov.File.relevant_lines_count(f.coverage_lines || [])
+      prev_covered = if f.previous_coverage && f.previous_coverage > 0,
+        do: round(f.previous_coverage * relevant / 100),
+        else: 0
       current_covered = Opencov.File.covered_lines_count(f.coverage_lines || [])
       max(0, prev_covered - current_covered)
     end) |> Enum.sum()
@@ -151,6 +176,8 @@ defmodule Opencov.Integrations.Gitea do
       true -> "red"
     end
     badge_pct = build.coverage |> Float.round(0) |> trunc()
+
+    prev_build_number = if build.previous_build, do: "#{build.previous_build.build_number}", else: "N/A"
 
     """
     ## Pull Request Test Coverage Report for [Build #{build.build_number}](#{target_url})
@@ -169,7 +196,7 @@ defmodule Opencov.Integrations.Gitea do
 
     | **Totals** | ![coverage](https://img.shields.io/badge/coverage-#{badge_pct}%25-#{badge_color}) |
     |---|---|
-    | Change from base [Build #{previous_build_number(build)}](#{previous_build_url(build)}): | #{delta} |
+    | Change from base [Build #{prev_build_number}](#{previous_build_url(build)}): | #{delta} |
     | Covered Lines: | #{total_covered} |
     | Relevant Lines: | #{total_relevant} |
 
@@ -179,10 +206,7 @@ defmodule Opencov.Integrations.Gitea do
 
   defp format_files_table([], _target_url), do: ""
   defp format_files_table(files, target_url) do
-    header = """
-    | Files with Coverage Reduction | New Missed Lines | % |
-    |---|---|---|
-    """
+    header = "| Files with Coverage Reduction | New Missed Lines | % |\n|---|---|---|\n"
 
     rows = files
       |> Enum.map(fn f ->
@@ -192,7 +216,8 @@ defmodule Opencov.Integrations.Gitea do
           else: 0
         current_covered = Opencov.File.covered_lines_count(f.coverage_lines || [])
         missed = max(0, prev_covered - current_covered)
-        "| [#{f.name}](#{target_url}/source?filename=#{URI.encode(f.name)}) | #{missed} | #{format_pct(f.coverage)} |"
+        safe_name = String.replace(f.name, "]", "\\]")
+        "| [#{safe_name}](#{target_url}/source?filename=#{URI.encode(f.name)}) | #{missed} | #{format_pct(f.coverage)} |"
       end)
       |> Enum.join("\n")
 
@@ -203,7 +228,7 @@ defmodule Opencov.Integrations.Gitea do
 
   defp format_pct(nil), do: "0%"
   defp format_pct(coverage) do
-    "#{Float.round(coverage * 1.0, 2)}%"
+    "#{Float.round(coverage, 2)}%"
   end
 
   defp format_delta(build) do
@@ -221,17 +246,6 @@ defmodule Opencov.Integrations.Gitea do
       if build.coverage >= build.previous_coverage, do: "increased", else: "decreased"
     else
       "is"
-    end
-  end
-
-  defp previous_build_number(build) do
-    if build.previous_build_id do
-      case Opencov.Repo.get(Opencov.Build, build.previous_build_id) do
-        nil -> "N/A"
-        prev -> "#{prev.build_number}"
-      end
-    else
-      "N/A"
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Opencov.Mixfile do
 
   def application do
     [mod: {Opencov, []},
-     extra_applications: [:logger, :eex]]
+     extra_applications: [:logger, :eex, :httpoison]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "web", "test/support"]
@@ -45,6 +45,7 @@ defmodule Opencov.Mixfile do
      {:secure_password, "~> 0.4"},
      {:seedex, "~> 0.1.3"},
      {:jason, "~> 1.2"},
+     {:httpoison, "~> 1.8"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:mix_test_watch, "~> 0.2", only: :dev},
      {:excoveralls, "~> 0.6", only: :test},

--- a/web/managers/build_manager.ex
+++ b/web/managers/build_manager.ex
@@ -34,6 +34,7 @@ defmodule Opencov.BuildManager do
     coverage = build |> Repo.preload(:jobs) |> compute_coverage
     build = Repo.update! change(build, coverage: coverage)
     Opencov.ProjectManager.update_coverage(Repo.preload(build, :project).project)
+    Opencov.Integrations.Gitea.notify(build)
     build
   end
 


### PR DESCRIPTION
## Summary

- Add Gitea integration that posts commit status and PR coverage comments after coverage upload
- Comments match Coveralls format: per-file breakdown, badge, delta, covered/relevant lines
- Comments are updated (not duplicated) on subsequent pushes via `<!-- opencov-report -->` marker
- Fire-and-forget via Task.start — never blocks coverage processing
- Add multi-arch Docker publish workflow to ghcr.io (linux/amd64 + linux/arm64)

## Changes

| File | What |
|---|---|
| `lib/opencov/integrations/gitea.ex` | New module — HTTP client, commit status, PR comment formatting |
| `web/managers/build_manager.ex` | Hook: call `Gitea.notify(build)` after coverage update |
| `mix.exs` | Add `httpoison` dependency |
| `config/config.exs` | Add `:gitea` config block |
| `.github/workflows/publish.yml` | Multi-arch Docker publish to ghcr.io |

## Config

Environment variables:
- `GITEA_ENABLED=true`
- `GITEA_URL=https://git.oboroworks.com`
- `GITEA_TOKEN=<api token with repo write>`

## Review findings fixed

- Runtime config reading (env vars checked at call time, not boot time)
- Empty PR number string guard
- Preload `previous_build` association to avoid N+1 queries
- Try/rescue wrapper around async Task
- Empty file list guard
- Markdown-safe filenames
- Safe JSON decode for existing comment search

Closes #1